### PR TITLE
Gateway now works with Consul

### DIFF
--- a/ApiGateway/Ocelot/ApiGateway.csproj
+++ b/ApiGateway/Ocelot/ApiGateway.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
+    <PackageReference Include="MMLib.SwaggerForOcelot" Version="2.5.1" />
     <PackageReference Include="Ocelot" Version="16.0.1" />
     <PackageReference Include="Ocelot.Administration" Version="16.0.1" />
     <PackageReference Include="Ocelot.Provider.Consul" Version="16.0.1" />

--- a/ApiGateway/Ocelot/Configuration/ocelot.global.json
+++ b/ApiGateway/Ocelot/Configuration/ocelot.global.json
@@ -47,7 +47,7 @@
       "Config": [
         {
           "Name": "Movies API",
-          "Version": "v0.9",
+          "Version": "v1",
           "Url": "http://localhost:8080/swagger/v1/swagger.movies.json"
         }
       ]
@@ -57,7 +57,7 @@
       "Config": [
         {
           "Name": "Reviews API",
-          "Version": "v0.9",
+          "Version": "v1",
           "Url": "http://localhost:8080/swagger/v1/swagger.reviews.json"
         }
       ]

--- a/ApiGateway/Ocelot/Configuration/ocelot.global.json
+++ b/ApiGateway/Ocelot/Configuration/ocelot.global.json
@@ -29,5 +29,38 @@
     "ExceptionsAllowedBeforeBreaking": 3,
     "DurationOfBreak": 10000,
     "TimeoutValue": 5000
-  }
+  },
+
+  "SwaggerEndPoints": [
+    {
+      "Key": "users",
+      "Config": [
+        {
+          "Name": "Users API",
+          "Version": "v1",
+          "Url": "http://localhost:8080/swagger/v1/swagger.users.json"
+        }
+      ]
+    },
+    {
+      "Key": "movies",
+      "Config": [
+        {
+          "Name": "Movies API",
+          "Version": "v0.9",
+          "Url": "http://localhost:8080/swagger/v1/swagger.movies.json"
+        }
+      ]
+    },
+    {
+      "Key": "reviews",
+      "Config": [
+        {
+          "Name": "Reviews API",
+          "Version": "v0.9",
+          "Url": "http://localhost:8080/swagger/v1/swagger.reviews.json"
+        }
+      ]
+    }
+  ]
 }

--- a/ApiGateway/Ocelot/Configuration/ocelot.movies.json
+++ b/ApiGateway/Ocelot/Configuration/ocelot.movies.json
@@ -8,7 +8,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "movies"
     },
     {
       "DownstreamPathTemplate": "/api/movies/{movieId}/reviews/{everything}",
@@ -18,7 +19,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "movies"
     },
     {
       "DownstreamPathTemplate": "/api/movies",
@@ -28,7 +30,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "movies"
     },
     {
       "DownstreamPathTemplate": "/api/movies/{everything}",
@@ -38,7 +41,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "movies"
     }
   ]
 }

--- a/ApiGateway/Ocelot/Configuration/ocelot.reviews.json
+++ b/ApiGateway/Ocelot/Configuration/ocelot.reviews.json
@@ -8,7 +8,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "reviews"
     },
     {
       "DownstreamPathTemplate": "/api/reviews/{everything}",
@@ -18,7 +19,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "reviews"
     }
   ]
 }

--- a/ApiGateway/Ocelot/Configuration/ocelot.users.json
+++ b/ApiGateway/Ocelot/Configuration/ocelot.users.json
@@ -8,7 +8,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "users"
     },
     {
       "DownstreamPathTemplate": "/api/users/{userId}/movies/{everything}",
@@ -18,7 +19,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "users"
     },
 
     {
@@ -29,7 +31,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "users"
     },
     {
       "DownstreamPathTemplate": "/api/users/{userId}/reviews/{everything}",
@@ -39,7 +42,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "users"
     },
 
     {
@@ -50,7 +54,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "users"
     },
     {
       "DownstreamPathTemplate": "/api/users/{everything}",
@@ -60,7 +65,8 @@
       "FileCacheOptions": { "TtlSeconds": 15 },
       "LoadBalancerOptions": {
         "Type": "LeastConnection"
-      }
+      },
+      "SwaggerKey": "users"
     }
   ]
 }

--- a/ApiGateway/Ocelot/Program.cs
+++ b/ApiGateway/Ocelot/Program.cs
@@ -7,7 +7,7 @@ namespace ApiGateway
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run(); 
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/ApiGateway/Ocelot/Startup.cs
+++ b/ApiGateway/Ocelot/Startup.cs
@@ -53,6 +53,7 @@ namespace ApiGateway
         public void ConfigureServices(IServiceCollection services)
         {
             services
+                .AddSwaggerForOcelot(Configuration)
                 .AddOcelot(Configuration)
                 .AddConsul()
                 .AddConfigStoredInConsul();
@@ -62,6 +63,10 @@ namespace ApiGateway
         public void Configure(IApplicationBuilder app)
         {
             app.UseStaticFiles();
+
+            app.UseSwaggerForOcelotUI(opt => {
+                opt.PathToSwaggerGenerator = "/swagger/docs";
+            });
 
             app
                 .UseOcelot()

--- a/ApiGateway/Ocelot/appsettings.json
+++ b/ApiGateway/Ocelot/appsettings.json
@@ -8,11 +8,11 @@
     }
   },
   "AllowedHosts": "*",
-
   "GlobalConfiguration": {
     "ServiceDiscoveryProvider": {
       "Type": "PollConsul",
-      "Host": "http://consul",
+      "Scheme": "http",
+      "Host": "consul",
       "Port": 8500,
       "ConfigurationKey": "ApiGateway_1",
       "PollingInterval": 100

--- a/Compose/docker-compose.ocelot.yml
+++ b/Compose/docker-compose.ocelot.yml
@@ -14,5 +14,6 @@ services:
       - users_service
       - movies_service
       - reviews_service
+      - consul
     depends_on:
       - consul

--- a/Src/MoviesService/appsettings.json
+++ b/Src/MoviesService/appsettings.json
@@ -51,6 +51,7 @@
   "ConsulOptions": {
     "ConsulAddress": "http://consul:8500",
     "ServiceAddress": "http://movies_service",
+    "ServiceName": "MoviesService",
     "DisableAgentCheck": false,
     "Tags": []
   },

--- a/Src/ReviewsService/appsettings.json
+++ b/Src/ReviewsService/appsettings.json
@@ -51,6 +51,7 @@
   "ConsulOptions": {
     "ConsulAddress": "http://consul:8500",
     "ServiceAddress": "http://reviews_service",
+    "ServiceName": "ReviewsService",
     "DisableAgentCheck": false,
     "Tags": []
   },

--- a/Src/UsersService/appsettings.json
+++ b/Src/UsersService/appsettings.json
@@ -51,6 +51,7 @@
   "ConsulOptions": {
     "ConsulAddress": "http://consul:8500",
     "ServiceAddress": "http://users_service",
+    "ServiceName": "UsersService",
     "DisableAgentCheck": false,
     "Tags": []
   },


### PR DESCRIPTION
There was a config error for consul. I also added some swagger stuff, not complete but it is a start.

<img width="1440" alt="Screenshot 2020-09-18 at 04 12 06" src="https://user-images.githubusercontent.com/3740700/93551190-338b4600-f965-11ea-8a34-6c33cdad31f7.png">
As you can see I successfully got a response from the gateway.

You may have to add this intention to allow the request:
<img width="1440" alt="Screenshot 2020-09-18 at 04 14 40" src="https://user-images.githubusercontent.com/3740700/93551331-7fd68600-f965-11ea-9d8d-b3f7842ee2d4.png">

Something else to note, I had tested the gateway by adding the post upstream, I noticed that in the users service that the address [http://localhost:8080/api/users](http://localhost:8080/api/users) is currently only a post to create a user. So I tried adding a user and got a error 500 (also tried with form-data and got a error 415). So a lot more work is needed to get a flow working. You can ignore the execution time, my laptop is slow.
<img width="1100" alt="Screenshot 2020-09-18 at 04 44 04" src="https://user-images.githubusercontent.com/3740700/93553038-efe70b00-f969-11ea-8939-d68d3e2309ba.png">

(update) it didn't work because I didn't migrate the database in docker, maybe you can do this automatically on startup?


